### PR TITLE
Make MaxElapsedTime configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,16 @@ func main() {
 
 }
 ```
+
+## Configuration
+
+The client will initialise with some sensible defaults which you can find [here](https://github.com/botsandus/retryable/blob/main/http_client.go) as part of the `HttpClient`.
+
+You can override these like so:
+
+```
+ c := retryable.New()
+ c.MaxRetries = 99                   // Will try a total of 100 times.
+ c.MaxInterval = 5 time.Minute       // Intervals between retries shouldn't exceed 5 minutes.
+ c.MaxElapsedTime = 10 * time.Minute // Stops retrying completely after 10 minutes.
+```

--- a/http_client.go
+++ b/http_client.go
@@ -35,16 +35,18 @@ var (
 type HttpClient struct {
 	*http.Client
 
-	MaxRetries  int
-	MaxInterval time.Duration
+	MaxRetries     int
+	MaxInterval    time.Duration
+	MaxElapsedTime time.Duration
 }
 
 // New returns an HttpClient with some retry logic attached
 func New() *HttpClient {
 	return &HttpClient{
-		MaxRetries:  9, // For a total of 10 calls, by default
-		MaxInterval: time.Second * 30,
-		Client:      http.DefaultClient,
+		MaxRetries:     9, // For a total of 10 calls, by default
+		MaxInterval:    time.Second * 30,
+		MaxElapsedTime: 0, // Never gonna give you up
+		Client:         http.DefaultClient,
 	}
 }
 
@@ -135,5 +137,5 @@ func (h HttpClient) DoWithContext(ctx context.Context, req *http.Request) (*http
 		return resp, nil
 	}
 
-	return backoff.Retry(ctx, operation, backoff.WithBackOff(bo), backoff.WithMaxElapsedTime(0))
+	return backoff.Retry(ctx, operation, backoff.WithBackOff(bo), backoff.WithMaxElapsedTime(h.MaxElapsedTime))
 }


### PR DESCRIPTION
## Summary

The underlying exponential backoff [library](https://github.com/cenkalti/backoff) this uses has a default [MaxElapsedTime](https://github.com/cenkalti/backoff/blob/7cad66a637c4ffff09d0795608116ddcc7eb1769/retry.go#L10) of 15 minutes if not explicitly set using [WithMaxElapsedTime](https://github.com/cenkalti/backoff/blob/7cad66a637c4ffff09d0795608116ddcc7eb1769/retry.go#L58).

This effectively stops retries when exceeded, regardless of what is set for `MaxRetries` and `MaxInterval`.

This change exposes that as a configurable value also called `MaxElapsedTime` where if not explicitly set, will use the default of `0` - meaning it will continue to retry indefinitely.