### PR TITLE
PT-3069 allow setting MaxRetries=0 so MaxElapsedTime can be used to control behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,14 @@ You can override these like so:
  c.MaxInterval = 5 time.Minute       // Intervals between retries shouldn't exceed 5 minutes.
  c.MaxElapsedTime = 10 * time.Minute // Stops retrying completely after 10 minutes.
 ```
+
+### Retry behavior gotchas
+
+The retry behavior is controlled by two parameters:
+
+- **MaxRetries**: Controls the maximum number of retry attempts (not including the initial attempt)
+- **MaxElapsedTime**: Controls the maximum total time spent retrying
+
+If you set `MaxRetries = 0` - Retries are controlled only by **MaxElapedTime**. The client will keep retrying until **MaxElapsedTime** is exceeded.
+
+If you set `MaxElapsedTime = 0` - Retries are controlled only by **MaxRetries**. The client will keep trying until **MaxRetries** is exceeded.

--- a/http_client.go
+++ b/http_client.go
@@ -81,7 +81,10 @@ func (h HttpClient) DoWithContext(ctx context.Context, req *http.Request) (*http
 		//
 		// Note that we add `1` to the number of MaxRetries since the first
 		// attempt isn't a retry, it's a _try_
-		if metadata.requests >= h.MaxRetries+1 {
+		//
+		// MaxRetries may be 0 to override the retry logic and instead base it on MaxElapsedTime.
+		// In which case this won't apply.
+		if h.MaxRetries > 0 && metadata.requests >= h.MaxRetries+1 {
 			return nil, &backoff.PermanentError{
 				Err: MaxAttemptsReachedError{c: h.MaxRetries + 1},
 			}


### PR DESCRIPTION
## Summary of Changes

To make configuration a bit more intuitive for end users, we can allow control via a time-based method rather than relying on an arbitrary combination of `MaxRetries` and `MaxInterval`.

This change allows the client to set `MaxRetries = 0` - this will offload the control for the retry behaviour to whatever value is set for `MaxElapsedTime`.

Example:

`MaxElapsedTime = 5 * time.Minute`
`MaxRetries = 0`

The request will finally fail once the elapsed time for retrying has exceeded 5 minutes.